### PR TITLE
🥧 Fix Typescript Vercel setup

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -30,4 +30,4 @@ app.use(function (req: Request, res: Response, next) {
 
 app.use(errorHandler);
 
-module.exports = app;
+export default app;

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -30,4 +30,4 @@ app.use(function (req: Request, res: Response, next) {
 
 app.use(errorHandler);
 
-export default app;
+module.exports = app;

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,10 @@
     "PROD_MONGO_URL": "@ssw_db_url"
   },
   "builds": [
-    { "src": "api/src/app.js", "use": "@now/node" },
+    { "src": "api/src/app.ts", "use": "@vercel/node" },
     {
       "src": "client/package.json",
-      "use": "@now/static-build",
+      "use": "@vercel/static-build",
       "config": { "distDir": "build" }
     }
   ],
@@ -17,7 +17,7 @@
       "headers": {
         "cache-control": "s-maxage=0"
       },
-      "dest": "api/src/app.js"
+      "dest": "api/src/app.ts"
     },
     {
       "src": "/static/(.*)",


### PR DESCRIPTION
Fixes `vercel.json` to point to the proper TypeScript endpoint - bug originates from #5. 