### PR TITLE
[WIP] Add Resource visibility tag functionality

### DIFF
--- a/api/src/api/resources.ts
+++ b/api/src/api/resources.ts
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import { errorWrap } from '../middleware';
 import { requireAdmin, requireRegistered } from '../middleware/auth';
 
+import { visibilityEnum } from '../utils/enums';
 import Resource from '../models/resource';
 
 const router = express.Router();
@@ -18,6 +19,19 @@ router.get(
   '/',
   requireRegistered,
   errorWrap(async (req: Request, res: Response) => {
+    // If user does not have an approved role, only show public resources
+    if (!req.user.hasRoleApproved) {
+      const resources = await Resource.find({
+        visibility: visibilityEnum.PUBLIC,
+      });
+      res.status(200).json({
+        message: `Successfully retrieved all resources.`,
+        success: true,
+        result: resources,
+      });
+    }
+
+    // If user is admin, return all resources
     const resources = await Resource.find({});
     res.status(200).json({
       message: `Successfully retrieved all resources.`,

--- a/api/src/models/resource.ts
+++ b/api/src/models/resource.ts
@@ -1,6 +1,8 @@
 import mongoose, { Document } from 'mongoose';
 import { IResource } from 'ssw-common';
 
+import { visibilityEnum } from '../utils/enums';
+
 type ResourceSchema = IResource & Document<any>;
 
 /**
@@ -10,5 +12,11 @@ const Resource = new mongoose.Schema({
   name: { type: String, default: null, required: true },
   link: { type: String, default: null, required: true },
   teamRoles: [{ type: String, default: null, required: true }],
+  visibility: {
+    type: String,
+    enum: Object.values(visibilityEnum),
+    default: visibilityEnum.PRIVATE,
+    required: true,
+  },
 });
 export default mongoose.model<ResourceSchema>('Resource', Resource);

--- a/api/src/utils/enums.ts
+++ b/api/src/utils/enums.ts
@@ -55,6 +55,11 @@ const assignmentStatusEnum = {
   NONE: 'NONE',
 };
 
+const visibilityEnum = {
+  PUBLIC: 'PUBLIC',
+  PRIVATE: 'PRIVATE',
+};
+
 export {
   interestsEnum,
   rolesEnum,
@@ -62,4 +67,5 @@ export {
   onboardingStatusEnum,
   pitchStatusEnum,
   assignmentStatusEnum,
+  visibilityEnum,
 };


### PR DESCRIPTION
## Summary
Ref #115 

## Changes
- Add `visibility` tag on Resource model
- Edit Resource api endpoints to return only public resources if user does not have an approved role

## Screenshots

(Insert image, only for frontend)

## Requests / Responses

**Request**
(Only for backend)
POST `/api/users` Returns a list of users

```
{
  "data": {
    "attributes": {
      "name": "The Dude",
      "email": "thedudeabides@wee.net",
      "password": "hellopassword"
    }
  },
  "type": "users"
}
```

**Response**
(Only for backend)
HTTP/1.1 200 OK

```
{
  "data": {
    "type": "users",
    "id": "4",
    "attributes": {
      "name": "The Dude",
      "email": "thedudeabides@wee.net",
      "last-logged-in": null,
      "created-at": "2016-10-20T17:45:08.190Z",
      "updated-at": "2016-10-20T17:45:08.190Z"
    },
    "links": {
      "self": "/users/4"
    }
  }
}
```
