### PR TITLE
Fix Editable Tags Modal

### DIFF
--- a/client/src/components/Modals/EditableTags/EditInterests.tsx
+++ b/client/src/components/Modals/EditableTags/EditInterests.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react';
-import { IInterest } from 'ssw-common';
 
 import { createManyInterests, updateManyInterests } from '../../../api';
 import { useInterests } from '../../../contexts';
@@ -9,22 +8,13 @@ import EditableTagModal from './EditableTag';
 const EditInterests = (): ReactElement => {
   const { interests, fetchInterests } = useInterests();
 
-  const submitInterest = (interests: Partial<IInterest>[]): void => {
-    createManyInterests(interests);
-    fetchInterests();
-  };
-
-  const updateInterest = (interests: IInterest[]): void => {
-    updateManyInterests(interests);
-    fetchInterests();
-  };
-
   return (
     <EditableTagModal
       title="Interests"
       allTags={interests}
-      onCreate={submitInterest}
-      onUpdate={updateInterest}
+      onCreate={createManyInterests}
+      onUpdate={updateManyInterests}
+      onFetch={fetchInterests}
     />
   );
 };

--- a/client/src/components/Modals/EditableTags/EditTeams.tsx
+++ b/client/src/components/Modals/EditableTags/EditTeams.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react';
-import { ITeam } from 'ssw-common';
 
 import { createManyTeams, updateManyTeams } from '../../../api';
 import { useTeams } from '../../../contexts';
@@ -9,22 +8,13 @@ import EditableTagModal from './EditableTag';
 const EditTeams = (): ReactElement => {
   const { teams, fetchTeams } = useTeams();
 
-  const submitTeam = (teams: Partial<ITeam>[]): void => {
-    createManyTeams(teams);
-    fetchTeams();
-  };
-
-  const updateTeam = (teams: ITeam[]): void => {
-    updateManyTeams(teams);
-    fetchTeams();
-  };
-
   return (
     <EditableTagModal
       title="Teams"
       allTags={teams}
-      onCreate={submitTeam}
-      onUpdate={updateTeam}
+      onCreate={createManyTeams}
+      onUpdate={updateManyTeams}
+      onFetch={fetchTeams}
     />
   );
 };

--- a/client/src/components/Modals/EditableTags/EditableTag.tsx
+++ b/client/src/components/Modals/EditableTags/EditableTag.tsx
@@ -31,6 +31,7 @@ interface EditableTagModalProps extends ModalProps {
   allTags: Tag[];
   onCreate: (tags: Partial<Tag>[]) => void;
   onUpdate: (tags: Tag[]) => void;
+  onFetch: () => void;
 }
 
 const EditableTagModal: FC<EditableTagModalProps> = ({
@@ -38,6 +39,7 @@ const EditableTagModal: FC<EditableTagModalProps> = ({
   allTags,
   onCreate,
   onUpdate,
+  onFetch,
   ...rest
 }): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
@@ -56,7 +58,7 @@ const EditableTagModal: FC<EditableTagModalProps> = ({
     }));
 
     setClonedTags([...clone]);
-
+    onFetch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
@@ -138,6 +140,7 @@ const EditableTagModal: FC<EditableTagModalProps> = ({
         onUpdate(changedTags);
 
         setIsOpen(false);
+        onFetch();
         setFormValues([]);
 
         Swal.fire(


### PR DESCRIPTION
## Summary

Tiny fix of #173 and #168 

## Changes

- Fetch team and interest after the modal is closed so that changes are not saved (without clicking save) on the frontend when reopening the modal.