### PR TITLE
Filter claimable teams

### DIFF
--- a/client/src/components/Tables/PitchDoc/index.tsx
+++ b/client/src/components/Tables/PitchDoc/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactElement, useEffect, useState } from 'react';
 import { Table } from 'semantic-ui-react';
-import { IPitch, IUser } from 'ssw-common';
+import { IPitch } from 'ssw-common';
 
 import {
   ApprovePitchModal,
@@ -12,6 +12,7 @@ import {
 import { useAuth, useInterests, useTeams } from '../../../contexts';
 import { pitchDocTabs } from '../../../utils/constants';
 import './styles.scss';
+import { getClaimableTeams } from '../../../utils/helpers';
 
 interface PitchTableProps {
   pitches: IPitch[];
@@ -132,13 +133,6 @@ const PitchBody: FC<PitchBodyProps> = ({
     })}
   </>
 );
-
-const getClaimableTeams = (pitch: IPitch, user: IUser): string[] =>
-  pitch.writer
-    ? pitch.teams
-        .filter((team) => team.target > 0 && user.teams.includes(team.teamId))
-        .map((team) => team.teamId)
-    : [];
 
 const PitchRow: FC<PitchRowProps> = ({ pitch, ...rest }): ReactElement => {
   const { user } = useAuth();

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -64,6 +64,20 @@ const getUserShortName = (user: Partial<IUser>): string =>
   `${user.preferredName || user.firstName} ${user.lastName?.slice(0, 1)}.`;
 
 /**
+ * Gets the teams on a pitch that a user can claimed
+ *
+ * @param pitch the pitch to check the teams for
+ * @param user the user to check the teams for
+ * @returns the teams that the user can claim
+ */
+const getClaimableTeams = (pitch: IPitch, user: IUser): string[] =>
+  pitch.writer
+    ? pitch.teams
+        .filter((team) => team.target > 0 && user.teams.includes(team.teamId))
+        .map((team) => team.teamId)
+    : [];
+
+/**
  * Parses an array of options into Semantic UI style Dropdown Items objects
  *
  * @param options the dropdown options to create
@@ -178,6 +192,7 @@ export {
   updateUserField,
   getUserFullName,
   getUserShortName,
+  getClaimableTeams,
   parseOptions,
   parseOptionsSelect,
   isPitchClaimed,


### PR DESCRIPTION
## Summary

Filter pitches under "Claim a Pitch" tab so that only pitches with teams that the user can join show up
Closes #167 

## Changes

- Created helper function to filter pitches to only those with open teams that match the user (using Sahi/Bryan's logic flow)
- Integrate filter functionality into the pitch doc page

## Screenshots

Original view (shows all unclaimed pitches): 
![image](https://user-images.githubusercontent.com/45826922/141368757-df865532-6f97-48f6-aab2-cb37956df30a.png)

Updated view (shows only pitches that the user can claim):
![image](https://user-images.githubusercontent.com/45826922/141369082-003967d0-d4b0-41d4-8653-245bacc75d43.png)
