### PR TITLE
Restrict Admin from approving their own Pitch

### DIFF
--- a/client/src/components/Modals/ApprovePitch/styles.scss
+++ b/client/src/components/Modals/ApprovePitch/styles.scss
@@ -1,10 +1,10 @@
 @import '../../../styles/colors.scss';
 
 .approve-pitch-modal {
-  .content {
+  .review-pitch-content {
     background-color: $mainBackground !important;
   }
-  .header {
+  .review-pitch-header {
     background-color: $primary !important;
     color: white !important;
   }

--- a/client/src/pages/pitchDoc/index.tsx
+++ b/client/src/pages/pitchDoc/index.tsx
@@ -175,20 +175,20 @@ const PitchDoc = (): ReactElement => {
           onClick={(e, { name }) => setCurrentTab(name!)}
         />
 
-        <StaffView>
+        <AdminView>
           <Menu.Item
             name={pitchDocTabs.PITCH_APPROVAL}
             active={pitchDocTabs.PITCH_APPROVAL === currentTab}
             onClick={(e, { name }) => setCurrentTab(name!)}
           />
-        </StaffView>
-        <AdminView>
+        </AdminView>
+        <StaffView>
           <Menu.Item
             name={pitchDocTabs.CLAIM_APPROVAL}
             active={pitchDocTabs.CLAIM_APPROVAL === currentTab}
             onClick={(e, { name }) => setCurrentTab(name!)}
           />
-        </AdminView>
+        </StaffView>
       </Menu>
       <div className="search-add-wrapper">
         <Input


### PR DESCRIPTION
## Summary
closes #156 
Description of PR here...
- Staff can see Assign Pitch Contributors tab but not the Review Pitches tab
- Admin cannot review or decline their own pitches 

## Changes

- Restrict admin from approving/declining their own pitch by disabling buttons and functionality
- Show message to admin when viewing own pitch
- Fix tabs the staff can view

## Screenshots

![image](https://user-images.githubusercontent.com/13949280/141414307-ecc74494-ad0b-4b97-8855-7e7cf0fe2bc7.png)
![image](https://user-images.githubusercontent.com/13949280/141414330-dd81a2e2-a555-4dae-9f70-36714d7a6d6b.png)

what staff can see:
![image](https://user-images.githubusercontent.com/13949280/141414690-225626a4-59e9-4078-ba0b-97f639b6a7aa.png)
what admin can see:
![image](https://user-images.githubusercontent.com/13949280/141414743-6e88f311-870f-42bc-95ec-0da5dcd7ed99.png)
