### PR TITLE
Onboarding Status Endpoints & Email Sends

### DIFF
--- a/api/src/api/users.ts
+++ b/api/src/api/users.ts
@@ -14,6 +14,9 @@ import { onboardingStatusEnum, rolesEnum } from '../utils/enums';
 import { aggregateUser } from '../utils/aggregate-utils';
 import timezone from '../middleware/timezone';
 
+import { approveUser, declineUser } from '../utils/mailer-templates';
+import { sendMail } from '../utils/mailer';
+
 const router = express.Router();
 
 // Gets all users
@@ -367,6 +370,66 @@ router.post(
     res.status(200).json({
       success: true,
       message: 'Successfully updated user documents',
+    });
+  }),
+);
+
+// Approve a user, set status to onboarded
+router.put(
+  '/:userId/approved',
+  requireAdmin,
+  errorWrap(async (req: Request, res: Response) => {
+    const updatedUser = await User.findByIdAndUpdate(
+      req.params.userId,
+      { onboardingStatus: onboardingStatusEnum.ONBOARDED },
+      { new: true, runValidators: true },
+    ).lean();
+
+    const message = approveUser(updatedUser, req.user);
+    await sendMail(message);
+
+    if (!updatedUser) {
+      res.status(404).json({
+        success: false,
+        message: 'User not found with id',
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      message: 'Successfully onboarded user',
+      result: updatedUser,
+    });
+  }),
+);
+
+// Decline a user, set status to denied
+router.put(
+  '/:userId/denied',
+  requireAdmin,
+  errorWrap(async (req: Request, res: Response) => {
+    const updatedUser = await User.findByIdAndUpdate(
+      req.params.userId,
+      { onboardingStatus: onboardingStatusEnum.DENIED },
+      { new: true, runValidators: true },
+    );
+
+    const message = declineUser(updatedUser, req.user);
+    await sendMail(message);
+
+    if (!updatedUser) {
+      res.status(404).json({
+        success: false,
+        message: 'User not found with id',
+      });
+      return;
+    }
+
+    res.status(200).json({
+      success: true,
+      message: 'Successfully denied user',
+      result: updatedUser,
     });
   }),
 );

--- a/api/src/utils/mailer-templates.ts
+++ b/api/src/utils/mailer-templates.ts
@@ -217,3 +217,39 @@ export const declineClaim = (
   );
   return basicEmail;
 };
+
+export const approveUser = (user: IUser, admin: IUser): EmailMessage => {
+  const basicEmail = buildEmailQuery(
+    user.email,
+    `Welcome to the South Side Weekly Contributor Dashboard!`,
+    `Hi ${user.preferredName || user.firstName},
+    <br><br>
+    Your request to join the South Side Weekly contributor dashboard as a ${user.role.toLocaleLowerCase()} has been approved. You can login using your email here: <a href="https://ssw.h4i.app/login">ssw.h4i.app/login</a>.
+    <br>
+    We can't wait to see the work that you do here at South Side Weekly!
+    <br><br>
+    Thank you, 
+    <br>
+    ${admin.preferredName || admin.firstName}
+    `,
+  );
+  return basicEmail;
+};
+
+export const declineUser = (user: IUser, admin: IUser): EmailMessage => {
+  const basicEmail = buildEmailQuery(
+    user.email,
+    `South Side Weekly Contributor Dashboard Access Update`,
+    `Hi ${user.preferredName || user.firstName},
+    <br><br>
+    We appreciate you applying to be a ${user.role.toLocaleLowerCase()} at South Side Weekly. Unfortunately, your request to join the South Side Weekly contributor dashboard as a ${user.role.toLocaleLowerCase()} has been declined.
+    <br>
+    Please contact ${admin.email} if you have any questions.
+    <br><br>
+    Thank you, 
+    <br>
+    ${admin.preferredName || admin.firstName}
+    `,
+  );
+  return basicEmail;
+};

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -6,6 +6,8 @@ export {
   updateUser,
   getUserPermissionsByID,
   updateOnboardingStatus,
+  approveUser,
+  declineUser,
 } from './user';
 export {
   getApprovedPitches,

--- a/client/src/api/user/index.ts
+++ b/client/src/api/user/index.ts
@@ -116,6 +116,23 @@ const getUsersByTeam = async (
   return await get(url, failureMessage);
 };
 
+// Approve user
+const approveUser = async (
+  userId: string,
+): Promise<Response<UsersResponse>> => {
+  const url = buildEndpoint(USER_ENDPOINT, userId, 'approved');
+  const failureMessage = 'APPROVE_USER_FAIL';
+  return await put(url, onboardingStatusEnum.ONBOARDED, failureMessage);
+};
+
+const declineUser = async (
+  userId: string,
+): Promise<Response<UsersResponse>> => {
+  const url = buildEndpoint(USER_ENDPOINT, userId, 'denied');
+  const failureMessage = 'DECLINE_USER_FAIL';
+  return await put(url, onboardingStatusEnum.DENIED, failureMessage);
+};
+
 export {
   getUsers,
   getPendingUsers,
@@ -127,4 +144,6 @@ export {
   updateOnboardingStatus,
   addVisitedPage,
   getUsersByTeam,
+  approveUser,
+  declineUser,
 };

--- a/client/src/components/Modals/ReviewUser/index.tsx
+++ b/client/src/components/Modals/ReviewUser/index.tsx
@@ -12,7 +12,7 @@ import {
 import { IUser } from 'ssw-common';
 import { isError } from 'lodash';
 
-import { updateUser, updateOnboardingStatus } from '../../../api';
+import { approveUser, declineUser, updateUser } from '../../../api';
 import { useInterests, useTeams } from '../../../contexts';
 import { UserPicture, FieldTag } from '../..';
 import { getUserFullName, titleCase } from '../../../utils/helpers';
@@ -40,14 +40,14 @@ const ReviewUserModal: FC<ReviewUserProps> = ({ user }): ReactElement => {
     });
 
   // Handle approve
-  const approveUser = (user: IUser): void => {
+  const handleApprove = (user: IUser): void => {
     const reasoningAdded = updateUser(
       {
         onboardReasoning: formValue,
       },
       user._id,
     );
-    const userApproved = updateOnboardingStatus(user._id, 'ONBOARDED');
+    const userApproved = approveUser(user._id);
     if (!isError(reasoningAdded) && !isError(userApproved)) {
       notifySuccess();
       setIsOpen(false);
@@ -63,14 +63,14 @@ const ReviewUserModal: FC<ReviewUserProps> = ({ user }): ReactElement => {
     return `${month}/${day}/${year}`;
   };
 
-  const declineUser = (user: IUser): void => {
+  const handleDecline = (user: IUser): void => {
     const reasoningAdded = updateUser(
       {
         onboardReasoning: formValue,
       },
       user._id,
     );
-    const userDenied = updateOnboardingStatus(user._id, 'DENIED');
+    const userDenied = declineUser(user._id);
     if (!isError(reasoningAdded) && !isError(userDenied)) {
       notifyDecline();
       setIsOpen(false);
@@ -201,7 +201,7 @@ const ReviewUserModal: FC<ReviewUserProps> = ({ user }): ReactElement => {
           <Button
             className="approve-button"
             onClick={() => {
-              approveUser(user);
+              handleApprove(user);
             }}
           >
             Approve
@@ -209,7 +209,7 @@ const ReviewUserModal: FC<ReviewUserProps> = ({ user }): ReactElement => {
           <Button
             className="decline-button"
             onClick={() => {
-              declineUser(user);
+              handleDecline(user);
             }}
           >
             Decline


### PR DESCRIPTION
## Summary

Send user email when admin approve/reject a user. 
Closes #183

## Changes

- Add email templates for reject user and approve user 
- Link reject and approve button to new endpoints `/userId/approved`, `/userId/denied`
- Send email when user is rejected or approved 

## Screenshots
<img width="1100" alt="Screen Shot 2021-11-16 at 9 16 41 PM" src="https://user-images.githubusercontent.com/61670566/142128255-65f50517-5191-46f8-a90a-ec0df1f9db4f.png">

