### PR TITLE
Add contributor active status

### DIFF
--- a/api/src/api/pitch.ts
+++ b/api/src/api/pitch.ts
@@ -182,6 +182,7 @@ router.post(
       $addToSet: {
         submittedPitches: newPitch._id,
       },
+      lastActive: new Date(),
     });
 
     if (newPitch) {

--- a/api/src/api/users.ts
+++ b/api/src/api/users.ts
@@ -172,7 +172,10 @@ router.put(
 
     const updatedUser = await User.findByIdAndUpdate(
       req.params.userId,
-      { $addToSet: { claimedPitches: req.body.pitchId } },
+      {
+        $addToSet: { claimedPitches: req.body.pitchId },
+        lastActive: new Date(),
+      },
       { new: true, runValidators: true },
     );
     if (!updatedUser) {

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -39,6 +39,7 @@ const User = new mongoose.Schema({
   teams: [{ type: Schema.Types.ObjectId, ref: 'Team' }],
   involvementResponse: { type: String, default: null },
   onboardReasoning: { type: String, default: null },
+  lastActive: { type: Date, default: Date.now },
 
   role: {
     type: String,

--- a/client/src/components/StatusTag/index.tsx
+++ b/client/src/components/StatusTag/index.tsx
@@ -10,27 +10,26 @@ interface StatusTagProps extends LabelProps {
 }
 
 const ACTIVE_PERIOD = 3;
-const RECENTLY_ACTIVE_PERIOD = 12;
 
 const StatusTag: FC<StatusTagProps> = ({ user, ...rest }) => {
   const getStatus = (): string => {
     const lastActive = new Date(user.lastActive);
     const now = new Date();
 
-    const latestActiveStartPeriod = new Date(
+    const threeMonthsAgo = new Date(
       now.getUTCFullYear(),
       now.getUTCMonth() - ACTIVE_PERIOD,
       now.getUTCDate(),
     );
-    const latestRecentlyActiveStartPeriod = new Date(
-      now.getUTCFullYear(),
-      now.getUTCMonth() - RECENTLY_ACTIVE_PERIOD,
+    const oneYearAgo = new Date(
+      now.getUTCFullYear() - 1,
+      now.getUTCMonth(),
       now.getUTCDate(),
     );
 
-    if (lastActive >= latestActiveStartPeriod) {
+    if (lastActive >= threeMonthsAgo) {
       return statusEnum.ACTIVE;
-    } else if (lastActive >= latestRecentlyActiveStartPeriod) {
+    } else if (lastActive >= oneYearAgo) {
       return statusEnum.RECENTLY_ACTIVE;
     }
 

--- a/client/src/components/StatusTag/index.tsx
+++ b/client/src/components/StatusTag/index.tsx
@@ -9,27 +9,25 @@ interface StatusTagProps extends LabelProps {
   user: IUser;
 }
 
+const MONTHS_IN_YEAR = 12;
+
 const ACTIVE_PERIOD = 3;
+const RECENTLY_ACTIVE = MONTHS_IN_YEAR;
 
 const StatusTag: FC<StatusTagProps> = ({ user, ...rest }) => {
   const getStatus = (): string => {
     const lastActive = new Date(user.lastActive);
     const now = new Date();
 
-    const threeMonthsAgo = new Date(
-      now.getUTCFullYear(),
-      now.getUTCMonth() - ACTIVE_PERIOD,
-      now.getUTCDate(),
-    );
-    const oneYearAgo = new Date(
-      now.getUTCFullYear() - 1,
-      now.getUTCMonth(),
-      now.getUTCDate(),
-    );
+    let months =
+      (now.getUTCFullYear() - lastActive.getUTCFullYear()) * MONTHS_IN_YEAR;
+    months -= lastActive.getUTCMonth();
+    months += now.getUTCMonth();
+    months = months <= 0 ? 0 : months;
 
-    if (lastActive >= threeMonthsAgo) {
+    if (months <= ACTIVE_PERIOD) {
       return statusEnum.ACTIVE;
-    } else if (lastActive > oneYearAgo) {
+    } else if (months <= RECENTLY_ACTIVE) {
       return statusEnum.RECENTLY_ACTIVE;
     }
 

--- a/client/src/components/StatusTag/index.tsx
+++ b/client/src/components/StatusTag/index.tsx
@@ -29,7 +29,7 @@ const StatusTag: FC<StatusTagProps> = ({ user, ...rest }) => {
 
     if (lastActive >= threeMonthsAgo) {
       return statusEnum.ACTIVE;
-    } else if (lastActive >= oneYearAgo) {
+    } else if (lastActive > oneYearAgo) {
       return statusEnum.RECENTLY_ACTIVE;
     }
 

--- a/client/src/components/StatusTag/index.tsx
+++ b/client/src/components/StatusTag/index.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react';
+import { LabelProps } from 'semantic-ui-react';
+import { IUser } from 'ssw-common';
+
+import { FieldTag } from '..';
+import { statusEnum } from '../../utils/enums';
+
+interface StatusTagProps extends LabelProps {
+  user: IUser;
+}
+
+const ACTIVE_PERIOD = 3;
+const RECENTLY_ACTIVE_PERIOD = 12;
+
+const StatusTag: FC<StatusTagProps> = ({ user, ...rest }) => {
+  const getStatus = (): string => {
+    const lastActive = new Date(user.lastActive);
+    const now = new Date();
+
+    const latestActiveStartPeriod = new Date(
+      now.getUTCFullYear(),
+      now.getUTCMonth() - ACTIVE_PERIOD,
+      now.getUTCDate(),
+    );
+    const latestRecentlyActiveStartPeriod = new Date(
+      now.getUTCFullYear(),
+      now.getUTCMonth() - RECENTLY_ACTIVE_PERIOD,
+      now.getUTCDate(),
+    );
+
+    if (lastActive >= latestActiveStartPeriod) {
+      return statusEnum.ACTIVE;
+    } else if (lastActive >= latestRecentlyActiveStartPeriod) {
+      return statusEnum.RECENTLY_ACTIVE;
+    }
+
+    return statusEnum.INACTIVE;
+  };
+
+  return <FieldTag content={getStatus()} {...rest} />;
+};
+
+export default StatusTag;

--- a/client/src/components/Tables/UserRecords/utils.tsx
+++ b/client/src/components/Tables/UserRecords/utils.tsx
@@ -10,6 +10,7 @@ import {
   UserTeams,
 } from '../..';
 import { getUserFullName } from '../../../utils/helpers';
+import StatusTag from '../../StatusTag';
 import { buildColumn } from '../DyanmicTable/util';
 import { fullNameSort, joinedSort, roleSort } from '../Util/TableUtil';
 
@@ -105,9 +106,9 @@ const viewUserColumn = buildColumn<IUser>({
 
 const activityColumn = buildColumn<IUser>({
   title: 'Active',
-  width: 1,
-  extractor: function getActivity(): ReactNode {
-    return <FieldTag size="tiny" content="Active" />;
+  width: 2,
+  extractor: function getActivity(user: IUser): ReactNode {
+    return <StatusTag user={user} size="tiny" />;
   },
 });
 

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -63,6 +63,7 @@ const emptyUser: IUser = {
   races: [],
   interests: [],
   onboardReasoning: '',
+  lastActive: new Date(),
 };
 
 const emptyPitch: IPitch = {

--- a/client/src/utils/enums.ts
+++ b/client/src/utils/enums.ts
@@ -61,3 +61,9 @@ export const visibilityEnum = {
   PUBLIC: 'PUBLIC',
   PRIVATE: 'PRIVATE',
 };
+
+export const statusEnum = {
+  ACTIVE: 'Active',
+  RECENTLY_ACTIVE: 'Recently Active',
+  INACTIVE: 'Inactive',
+};

--- a/common/index.d.ts
+++ b/common/index.d.ts
@@ -27,6 +27,7 @@ export interface IUser {
   races: string[];
   interests: string[];
   onboardReasoning: string;
+  lastActive: Date;
 }
 
 export interface IUserAggregate extends IUser {


### PR DESCRIPTION
## Summary

Resolves #150 
Adds activity attribute to users. 

## Changes

- Add lastActive field to user
- Add Status Tag component
- Define what it means to be active, recently active, and inactive
  - Active = lastActive within last 3 months
  - Recently Active = lastActive within last 12 months
  - Inactive = lastACtive 12 months or more
  - Submitting a Pitch or working on a pitch means that you are active

## Screenshots

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/66758185/143664343-7ee68bbf-ede0-44cc-910e-22ab0c664cdf.png">