### PR TITLE
Add Event Stop Propagation to Approve/Decline Buttons For Pending Users

### DIFF
--- a/client/src/components/table/columns.tsx
+++ b/client/src/components/table/columns.tsx
@@ -117,12 +117,18 @@ export const actionColumn = configureColumn<BasePopulatedUser>({
       <div style={{ display: 'flex' }}>
         <PrimaryButton
           size="mini"
-          onClick={() => approveUser(user)}
+          onClick={(e) => {
+            e.stopPropagation();
+            approveUser(user);
+          }}
           content="Approve"
         />
         <SecondaryButton
           size="mini"
-          onClick={() => rejectUser(user)}
+          onClick={(e) => {
+            e.stopPropagation();
+            rejectUser(user);
+          }}
           content="Decline"
           border
         />


### PR DESCRIPTION
## Summary

Clicking on approve/decline for pending user would open the review user modal. Adding event stop propagations prevents this from happening so just success toast appears for approving/declining pending user. 
 

