### PR TITLE
Final Bug Fixes

### DIFF
--- a/.github/workflows/update-stalled-users.yml
+++ b/.github/workflows/update-stalled-users.yml
@@ -9,6 +9,5 @@ jobs:
       - name: Call the update-stalled users API endpoint
         run: |
           curl --request POST \
-          --url 'https://south-side-weekly.vercel.app/api/users/stallUsers' \
+          --url 'https://hub.southsideweekly.com/api/users/stallUsers' \
           --header 'X-REQUEST-SECRET: ${{ secrets.REQUEST_SECRET }}'
-# TODO: update the endpoint and method to GET

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -8,3 +8,4 @@ export * as ResourceController from './resource.controller';
 export * as TeamController from './team.controller';
 export * as UserFeedbackController from './userFeedback.controller';
 export * as ConstantsController from './constants.controller';
+export * as NotificationController from './notification.controller';

--- a/api/src/controllers/notification.controller.ts
+++ b/api/src/controllers/notification.controller.ts
@@ -109,7 +109,7 @@ export const sendPitchApprovedNotification = async (
     contributor,
     reviewer,
     populatedPitch,
-    populatedPitch.writer?._id.toString() === contributorId,
+    populatedPitch.writer && populatedPitch.writer._id === contributorId,
   );
   sendSuccess(res, 'Pitch approved successfully');
 };

--- a/api/src/controllers/notification.controller.ts
+++ b/api/src/controllers/notification.controller.ts
@@ -105,16 +105,6 @@ export const sendPitchApprovedNotification = async (
 
   const reviewer = await UserService.getOne(reviewerId);
 
-  console.log(
-    'Writer id: ',
-    populatedPitch.writer && populatedPitch.writer._id,
-  );
-  console.log('Contributor id: ', contributorId);
-  console.log(
-    populatedPitch.writer &&
-      populatedPitch.writer._id.toString() === contributorId,
-  );
-
   await sendApprovedPitchMail(
     contributor,
     reviewer,

--- a/api/src/controllers/notification.controller.ts
+++ b/api/src/controllers/notification.controller.ts
@@ -105,11 +105,22 @@ export const sendPitchApprovedNotification = async (
 
   const reviewer = await UserService.getOne(reviewerId);
 
+  console.log(
+    'Writer id: ',
+    populatedPitch.writer && populatedPitch.writer._id,
+  );
+  console.log('Contributor id: ', contributorId);
+  console.log(
+    populatedPitch.writer &&
+      populatedPitch.writer._id.toString() === contributorId,
+  );
+
   await sendApprovedPitchMail(
     contributor,
     reviewer,
     populatedPitch,
-    populatedPitch.writer && populatedPitch.writer._id === contributorId,
+    populatedPitch.writer &&
+      populatedPitch.writer._id.toString() === contributorId,
   );
   sendSuccess(res, 'Pitch approved successfully');
 };

--- a/api/src/controllers/notification.controller.ts
+++ b/api/src/controllers/notification.controller.ts
@@ -1,0 +1,160 @@
+import { Request, Response } from 'express';
+import { BasePopulatedPitch } from 'ssw-common';
+import {
+  sendApprovedPitchMail,
+  sendApproveUserMail,
+  sendClaimRequestApprovedMail,
+  sendClaimRequestDeclinedMail,
+  sendContributorAddedToPitchMail,
+  sendDeclinedPitchMail,
+  sendRejectUserMail,
+} from '../mail/sender';
+import { populatePitch } from '../populators';
+import { PitchService, TeamService, UserService } from '../services';
+
+import { sendSuccess } from '../utils/helpers';
+
+export const sendUserApprovedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const reviewerId: string = req.body.reviewerId;
+
+  const contributor = await UserService.getOne(contributorId);
+  const reviewer = await UserService.getOne(reviewerId);
+
+  await sendApproveUserMail(contributor, reviewer);
+  sendSuccess(res, 'User approved successfully');
+};
+
+export const sendUserRejectedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const reviewerId: string = req.body.reviewerId;
+
+  const contributor = await UserService.getOne(contributorId);
+  const reviewer = await UserService.getOne(reviewerId);
+
+  await sendRejectUserMail(contributor, reviewer);
+
+  sendSuccess(res, 'User rejected successfully');
+};
+
+export const sendClaimRequestApprovedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const pitchId: string = req.body.pitchId;
+  const staffId: string = req.body.staffId;
+  const teamId: string = req.body.teamId;
+
+  const contributor = await UserService.getOne(contributorId);
+
+  const pitch = await PitchService.getOne(pitchId);
+  const populatedPitch = (await populatePitch(
+    pitch,
+    'default',
+  )) as BasePopulatedPitch;
+
+  const staff = await UserService.getOne(staffId);
+  const team = await TeamService.getOne(teamId);
+
+  await sendClaimRequestApprovedMail(contributor, populatedPitch, staff, team);
+
+  sendSuccess(res, 'Claim request approved successfully');
+};
+
+export const sendClaimRequestDeclinedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const pitchId: string = req.body.pitchId;
+  const staffId: string = req.body.staffId;
+
+  const contributor = await UserService.getOne(contributorId);
+
+  const pitch = await PitchService.getOne(pitchId);
+
+  const staff = await UserService.getOne(staffId);
+
+  await sendClaimRequestDeclinedMail(contributor, staff, pitch);
+
+  sendSuccess(res, 'Claim request declined successfully');
+};
+
+export const sendPitchApprovedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const pitchId: string = req.body.pitchId;
+  const reviewerId: string = req.body.reviewerId;
+
+  const contributor = await UserService.getOne(contributorId);
+
+  const pitch = await PitchService.getOne(pitchId);
+  const populatedPitch = (await populatePitch(
+    pitch,
+    'default',
+  )) as BasePopulatedPitch;
+
+  const reviewer = await UserService.getOne(reviewerId);
+
+  await sendApprovedPitchMail(
+    contributor,
+    reviewer,
+    populatedPitch,
+    pitch.writer === pitch.author,
+  );
+  sendSuccess(res, 'Pitch approved successfully');
+};
+
+export const sendPitchDeclinedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const staffId: string = req.body.staffId;
+  const pitchId: string = req.body.pitchId;
+  const reasoning: string | undefined = req.body.reasoning;
+
+  const contributor = await UserService.getOne(contributorId);
+  const staff = await UserService.getOne(staffId);
+
+  const pitch = await PitchService.getOne(pitchId);
+  const populatedPitch = (await populatePitch(
+    pitch,
+    'default',
+  )) as BasePopulatedPitch;
+
+  await sendDeclinedPitchMail(contributor, staff, populatedPitch, reasoning);
+
+  sendSuccess(res, 'Pitch declined successfully');
+};
+
+export const sendContributorAddedNotification = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const contributorId: string = req.body.contributorId;
+  const staffId: string = req.body.staffId;
+  const pitchId: string = req.body.pitchId;
+
+  const contributor = await UserService.getOne(contributorId);
+  const staff = await UserService.getOne(staffId);
+
+  const pitch = await PitchService.getOne(pitchId);
+  const populatedPitch = (await populatePitch(
+    pitch,
+    'default',
+  )) as BasePopulatedPitch;
+
+  await sendContributorAddedToPitchMail(contributor, staff, populatedPitch);
+
+  sendSuccess(res, 'Contributor added successfully');
+};

--- a/api/src/controllers/notification.controller.ts
+++ b/api/src/controllers/notification.controller.ts
@@ -109,7 +109,7 @@ export const sendPitchApprovedNotification = async (
     contributor,
     reviewer,
     populatedPitch,
-    pitch.writer.toString() === contributorId,
+    populatedPitch.writer?._id.toString() === contributorId,
   );
   sendSuccess(res, 'Pitch approved successfully');
 };

--- a/api/src/controllers/notification.controller.ts
+++ b/api/src/controllers/notification.controller.ts
@@ -109,7 +109,7 @@ export const sendPitchApprovedNotification = async (
     contributor,
     reviewer,
     populatedPitch,
-    pitch.writer === pitch.author,
+    pitch.writer.toString() === contributorId,
   );
   sendSuccess(res, 'Pitch approved successfully');
 };

--- a/api/src/controllers/pitch.controller.ts
+++ b/api/src/controllers/pitch.controller.ts
@@ -1,13 +1,6 @@
 import { Request, Response } from 'express';
 import { BasePopulatedPitch, Pitch } from 'ssw-common';
 
-import {
-  sendApprovedPitchMail,
-  sendClaimRequestApprovedMail,
-  sendClaimRequestDeclinedMail,
-  sendContributorAddedToPitchMail,
-  sendDeclinedPitchMail,
-} from '../mail/sender';
 import { populatePitch } from '../populators';
 import { PitchService, TeamService, UserService } from '../services';
 import { isWriterOrEditor } from '../services/pitch.service';
@@ -192,26 +185,6 @@ export const approvePitch = async (
     return;
   }
 
-  const populatedPitch = (await populatePitch(
-    pitch,
-    'default',
-  )) as BasePopulatedPitch;
-
-  sendApprovedPitchMail(
-    populatedPitch.author,
-    populatedPitch.reviewedBy,
-    populatedPitch,
-    req.body.writer === populatedPitch.author._id,
-  );
-
-  if (req.body.writer && req.body.writer !== populatedPitch.author._id) {
-    sendContributorAddedToPitchMail(
-      populatedPitch.writer,
-      populatedPitch.reviewedBy,
-      populatedPitch,
-    );
-  }
-
   sendSuccess(res, 'Pitch approved successfully', pitch);
 };
 
@@ -235,13 +208,6 @@ export const declinePitch = async (
     pitch,
     'default',
   )) as BasePopulatedPitch;
-
-  sendDeclinedPitchMail(
-    populatedPitch.author,
-    req.user,
-    populatedPitch,
-    req.body.reasoning,
-  );
 
   sendSuccess(res, 'Pitch declined successfully', populatedPitch);
 };
@@ -333,8 +299,6 @@ export const approveClaimRequest = async (
     'default',
   )) as BasePopulatedPitch;
 
-  sendClaimRequestApprovedMail(user, defaultPopulatedPitch, req.user, team);
-
   sendSuccess(res, 'Claim approved successfully', defaultPopulatedPitch);
 };
 
@@ -369,8 +333,6 @@ export const declineClaimRequest = async (
     sendNotFound(res, `User with id ${userId} not found`);
     return;
   }
-
-  sendClaimRequestDeclinedMail(user, req.user, pitch);
 
   const populateType = extractPopulateQuery(req.query);
 
@@ -484,13 +446,6 @@ export const addContributor = async (
     sendNotFound(res, `Pitch with id ${req.params.id} not found`);
     return;
   }
-
-  const populatedPitch = (await populatePitch(
-    pitch,
-    'default',
-  )) as BasePopulatedPitch;
-
-  sendContributorAddedToPitchMail(user, req.user, populatedPitch);
 
   sendSuccess(res, 'Successfully added contributor', pitch);
 };

--- a/api/src/controllers/resource.controller.ts
+++ b/api/src/controllers/resource.controller.ts
@@ -96,7 +96,11 @@ export const getResourceByName = async (
 ): Promise<void> => {
   const options = extractOptions(req.query);
 
-  const resource = await ResourceService.getByName(req.params.name, options);
+  const resource = await ResourceService.getByName(
+    req.user.onboardingStatus === onboardingStatusEnum.ONBOARDED,
+    req.params.name,
+    options,
+  );
 
   if (!resource) {
     sendNotFound(res, 'Resource not found');

--- a/api/src/controllers/user.controller.ts
+++ b/api/src/controllers/user.controller.ts
@@ -272,6 +272,7 @@ export const approveUser = async (
     sendNotFound(res, `User not found with id ${req.params.id}`);
     return;
   }
+  console.log('REACHED APPROVE USER ENDPOINT');
 
   sendApproveUserMail(user, req.user);
 

--- a/api/src/controllers/user.controller.ts
+++ b/api/src/controllers/user.controller.ts
@@ -9,7 +9,6 @@ import {
   sendUnauthorized,
 } from '../utils/helpers';
 import { getEditableFields, getViewableFields } from '../utils/user-utils';
-import { sendApproveUserMail, sendRejectUserMail } from '../mail/sender';
 import { TeamService, UserService, PitchService } from '../services';
 
 import { populateUser } from '../populators/user.populate';
@@ -274,8 +273,6 @@ export const approveUser = async (
   }
   console.log('REACHED APPROVE USER ENDPOINT');
 
-  await sendApproveUserMail(user, req.user);
-
   sendSuccess(
     res,
     'User onboarded successfully',
@@ -294,8 +291,6 @@ export const rejectUser = async (
     req.params.id,
     onboardingStatusEnum.DENIED,
   );
-
-  sendRejectUserMail(user, req.user);
 
   if (!user) {
     sendNotFound(res, `User not found with id ${req.params.id}`);

--- a/api/src/controllers/user.controller.ts
+++ b/api/src/controllers/user.controller.ts
@@ -274,7 +274,7 @@ export const approveUser = async (
   }
   console.log('REACHED APPROVE USER ENDPOINT');
 
-  sendApproveUserMail(user, req.user);
+  await sendApproveUserMail(user, req.user);
 
   sendSuccess(
     res,

--- a/api/src/mail/sender.ts
+++ b/api/src/mail/sender.ts
@@ -15,6 +15,7 @@ export const sendMail = async (mailOptions: SendMailOptions): Promise<void> => {
   });
 
   await mailDelivered;
+  console.log('RESOLVED');
 };
 
 export const sendRejectUserMail = (contributor: User, reviewer: User): void => {

--- a/api/src/mail/sender.ts
+++ b/api/src/mail/sender.ts
@@ -110,7 +110,7 @@ export const sendApprovedPitchMail = async (
     hasWriter ? 'pitchApprovedWriter.html' : 'pitchApprovedNoWriter.html',
     templateValues,
     {
-      cc: pitch.primaryEditor.email,
+      cc: hasWriter && pitch.primaryEditor.email,
     },
   );
 

--- a/api/src/mail/sender.ts
+++ b/api/src/mail/sender.ts
@@ -18,7 +18,10 @@ export const sendMail = async (mailOptions: SendMailOptions): Promise<void> => {
   console.log('RESOLVED');
 };
 
-export const sendRejectUserMail = (contributor: User, reviewer: User): void => {
+export const sendRejectUserMail = async (
+  contributor: User,
+  reviewer: User,
+): Promise<void> => {
   const templateValues = {
     contributor: contributor.fullname,
     role: contributor.role,
@@ -33,7 +36,7 @@ export const sendRejectUserMail = (contributor: User, reviewer: User): void => {
     templateValues,
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };
 
 export const sendApproveUserMail = async (
@@ -58,12 +61,12 @@ export const sendApproveUserMail = async (
   await sendMail(mailOptions);
 };
 
-export const sendClaimRequestApprovedMail = (
+export const sendClaimRequestApprovedMail = async (
   contributor: User,
   pitch: BasePopulatedPitch,
   staff: User,
   team: Team,
-): void => {
+): Promise<void> => {
   const templateValues = {
     contributor: contributor.fullname,
     title: pitch.title,
@@ -83,15 +86,15 @@ export const sendClaimRequestApprovedMail = (
     },
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };
 
-export const sendApprovedPitchMail = (
+export const sendApprovedPitchMail = async (
   contributor: UserFields,
   reviewer: UserFields,
   pitch: BasePopulatedPitch,
   hasWriter: boolean,
-): void => {
+): Promise<void> => {
   const templateValues = {
     contributor: contributor.fullname,
     pitch: pitch.title,
@@ -111,15 +114,15 @@ export const sendApprovedPitchMail = (
     },
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };
 
-export const sendDeclinedPitchMail = (
+export const sendDeclinedPitchMail = async (
   contributor: UserFields,
   staff: User,
   pitch: BasePopulatedPitch,
   reasoning?: string,
-): void => {
+): Promise<void> => {
   const templateValues = {
     contributor: contributor.fullname,
     title: pitch.title,
@@ -135,14 +138,14 @@ export const sendDeclinedPitchMail = (
     templateValues,
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };
 
-export const sendContributorAddedToPitchMail = (
+export const sendContributorAddedToPitchMail = async (
   contributor: UserFields,
   staff: UserFields,
   pitch: BasePopulatedPitch,
-): void => {
+): Promise<void> => {
   const templateValues = {
     contributor: contributor.fullname,
     primaryEditor: pitch.primaryEditor.fullname,
@@ -161,14 +164,14 @@ export const sendContributorAddedToPitchMail = (
     },
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };
 
-export const sendClaimRequestDeclinedMail = (
+export const sendClaimRequestDeclinedMail = async (
   contributor: User,
   staff: User,
   pitch: Pitch,
-): void => {
+): Promise<void> => {
   const templateValues = {
     staff: getUserFulName(staff),
     contributor: getUserFulName(contributor),
@@ -183,5 +186,5 @@ export const sendClaimRequestDeclinedMail = (
     templateValues,
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };

--- a/api/src/mail/sender.ts
+++ b/api/src/mail/sender.ts
@@ -36,10 +36,10 @@ export const sendRejectUserMail = (contributor: User, reviewer: User): void => {
   sendMail(mailOptions);
 };
 
-export const sendApproveUserMail = (
+export const sendApproveUserMail = async (
   contributor: User,
   reviewer: User,
-): void => {
+): Promise<void> => {
   console.log('REACHED SENDER FUNCTION');
   const templateValues = {
     contributor: getUserFulName(contributor),
@@ -55,7 +55,7 @@ export const sendApproveUserMail = (
     templateValues,
   );
 
-  sendMail(mailOptions);
+  await sendMail(mailOptions);
 };
 
 export const sendClaimRequestApprovedMail = (

--- a/api/src/mail/sender.ts
+++ b/api/src/mail/sender.ts
@@ -7,6 +7,7 @@ import transporter from './transporter';
 import { buildContributorHtml, buildSendMailOptions } from './utils';
 
 export const sendMail = async (mailOptions: SendMailOptions): Promise<void> => {
+  console.log('REACHED SEND MAIL');
   const mailDelivered = new Promise((resolve, reject) => {
     transporter.sendMail(mailOptions, (err, info) => {
       err ? reject(err) : resolve(info);
@@ -38,6 +39,7 @@ export const sendApproveUserMail = (
   contributor: User,
   reviewer: User,
 ): void => {
+  console.log('REACHED SENDER FUNCTION');
   const templateValues = {
     contributor: getUserFulName(contributor),
     role: contributor.role,

--- a/api/src/mail/templates/pitchApprovedNoWriter.ts
+++ b/api/src/mail/templates/pitchApprovedNoWriter.ts
@@ -9,7 +9,7 @@ export const pitchApprovedNoWriterHtml = `
     <p>Congratulations, your pitch {{ title }} has been approved! Here are the details you provided regarding the pitch:
     </p>
     <p><b>{{ description }}</b></p>
-    <p>Your pitch has been added to the <a href="{{ pitchDocLink }}">{{ pitchDocLink }}</a></p>
+    <p>Your pitch has been added to the pitch doc (<a href="{{ pitchDocLink }}">{{ pitchDocLink }}</a>)</p>
 
     <p>Thanks for submitting your pitch,</p>
     <p>{{ staff }} </p>

--- a/api/src/mail/templates/pitchApprovedWriter.ts
+++ b/api/src/mail/templates/pitchApprovedWriter.ts
@@ -9,7 +9,7 @@ export const pitchApprovedWriterHtml = `
     <p>Congratulations, your pitch {{ title }} has been approved! Here are the details you provided regarding the pitch:
     </p>
     <p><b>{{ description }}</b></p>
-    <p>Your pitch has been added to the <a href="{{ pitchDocLink }}">{{ pitchDocLink }}</a>. Your primary editor, {{
+    <p>Your pitch has been added to the pitch doc (<a href="{{ pitchDocLink }}">{{ pitchDocLink }}</a>). Your primary editor, {{
         primaryEditor }}, is cc’ed on this email
         and will be following up to begin discussing your story.</p>
 

--- a/api/src/mail/templates/pitchDeclined.ts
+++ b/api/src/mail/templates/pitchDeclined.ts
@@ -5,7 +5,7 @@ export const pitchDeclinedHtml = `
 
 <body>
     <p>Hi {{ contributor }}</p>
-    <br />
+ 
     <p>Thank you for submitting your pitch "{{ title }}". Unfortunately, your pitch was declined for the following
         reason:
     </p>
@@ -17,8 +17,6 @@ export const pitchDeclinedHtml = `
         pitch-writing {{ resourcesLink }} under the “Writing” tab. In the meantime, feel free to check the {{ pitchDocLink }} for potential
         new stories to claim!
     </p>
-    <br />
-
 
     <p>Thank you,</p>
     <p>{{ staff }} </p>

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -11,6 +11,7 @@ import pitchFeedbackRoutes from './pitchFeedback.routes';
 import pitchRoutes from './pitch.routes';
 import constantsRoutes from './constants.routes';
 import docsRoutes from './docs.routes';
+import notificationRoutes from './notification.routes';
 
 const router = Router();
 
@@ -25,5 +26,6 @@ router.use('/userFeedback', userFeedbackRoutes);
 router.use('/pitchFeedback', pitchFeedbackRoutes);
 router.use('/constants', constantsRoutes);
 router.use('/docs', docsRoutes);
+router.use('/notifications', notificationRoutes);
 
 export default router;

--- a/api/src/routes/notification.routes.ts
+++ b/api/src/routes/notification.routes.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+
+import { NotificationController } from '../controllers';
+import { errorWrap } from '../middleware';
+import { requireStaff } from '../middleware/auth';
+
+const router = Router();
+
+router.post(
+  '/sendUserApproved',
+  requireStaff,
+  errorWrap(NotificationController.sendUserApprovedNotification),
+);
+
+router.post(
+  '/sendUserRejected',
+  requireStaff,
+  errorWrap(NotificationController.sendUserRejectedNotification),
+);
+
+router.post(
+  '/sendClaimRequestApproved',
+  requireStaff,
+  errorWrap(NotificationController.sendClaimRequestApprovedNotification),
+);
+
+router.post(
+  '/sendClaimRequestDeclined',
+  requireStaff,
+  errorWrap(NotificationController.sendClaimRequestDeclinedNotification),
+);
+
+router.post(
+  '/sendPitchApproved',
+  requireStaff,
+  errorWrap(NotificationController.sendPitchApprovedNotification),
+);
+
+router.post(
+  '/sendPitchDeclined',
+  requireStaff,
+  errorWrap(NotificationController.sendPitchDeclinedNotification),
+);
+
+router.post(
+  '/sendContributorAdded',
+  requireStaff,
+  errorWrap(NotificationController.sendContributorAddedNotification),
+);
+
+export default router;

--- a/api/src/services/pitch.service.ts
+++ b/api/src/services/pitch.service.ts
@@ -427,6 +427,19 @@ export const removeEmptyPendingContributors = async (
   );
 };
 
+export const removeEmptyAssignmentContributors = async (
+  id: string,
+): Promise<void> => {
+  await updateModel(
+    { _id: id },
+    {
+      $pull: {
+        assignmentContributors: { teams: [] },
+      },
+    },
+  );
+};
+
 export const updateTeamTarget = async (
   _id: string,
   teamId: string,
@@ -643,6 +656,8 @@ export const removeContributor = async (
       },
     );
   }
+
+  await removeEmptyAssignmentContributors(_id);
 
   return pitch;
 };

--- a/api/src/services/resource.service.ts
+++ b/api/src/services/resource.service.ts
@@ -56,9 +56,19 @@ export const getOne = async (_id: string): Resource =>
   await Resource.findById({ _id }).lean();
 
 export const getByName = async (
+  isApproved: boolean,
   name: string,
   options?: PaginateOptions<ResourceSchema>,
-): Promise<ResourcesResponse> => await paginate({ teams: name }, options);
+): Promise<ResourcesResponse> => {
+  if (!isApproved) {
+    return await paginate(
+      { teams: name, visibility: visibilityEnum.PUBLIC },
+      options,
+    );
+  }
+
+  return await paginate({ teams: name }, options);
+};
 
 export const getAll = async (
   isApproved: boolean,

--- a/client/src/api/apiWrapper.ts
+++ b/client/src/api/apiWrapper.ts
@@ -167,7 +167,7 @@ export const approveUser = async (
     url: `/users/${user._id}/approve`,
   });
 
-  apiCall({
+  await apiCall({
     method: 'POST',
     url: `/notifications/sendUserApproved`,
     body: {

--- a/client/src/api/apiWrapper.ts
+++ b/client/src/api/apiWrapper.ts
@@ -154,10 +154,26 @@ export const loadEditors = async (): Promise<BasePopulatedUser[]> => {
   return [];
 };
 
-export const approveUser = async (user: BasePopulatedUser): Promise<void> => {
+export const approveUser = async (
+  user: BasePopulatedUser,
+  currentUser: BasePopulatedUser | undefined,
+): Promise<void> => {
+  if (!currentUser) {
+    return;
+  }
+
   const res = await apiCall({
     method: 'PUT',
     url: `/users/${user._id}/approve`,
+  });
+
+  apiCall({
+    method: 'POST',
+    url: `/notifications/sendUserApproved`,
+    body: {
+      contributorId: user._id,
+      reviewerId: currentUser._id,
+    },
   });
 
   if (!isError(res)) {
@@ -167,10 +183,25 @@ export const approveUser = async (user: BasePopulatedUser): Promise<void> => {
   }
 };
 
-export const rejectUser = async (user: BasePopulatedUser): Promise<void> => {
+export const rejectUser = async (
+  user: BasePopulatedUser,
+  currentUser: BasePopulatedUser | undefined,
+): Promise<void> => {
+  if (!currentUser) {
+    return;
+  }
+
   const res = await apiCall({
     method: 'PUT',
     url: `/users/${user._id}/deny`,
+  });
+  apiCall({
+    method: 'POST',
+    url: `/notifications/sendUserRejected`,
+    body: {
+      contributorId: user._id,
+      reviewerId: currentUser._id,
+    },
   });
 
   if (!isError(res)) {

--- a/client/src/components/card/ApproveClaimCard.tsx
+++ b/client/src/components/card/ApproveClaimCard.tsx
@@ -342,22 +342,23 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
         {assignmentContributors.map((contributor, idx) => (
           <div key={idx} className="claim-row">
             <UserChip user={contributor} />
-
-            <AuthView view="minStaff">
-              {completed ? (
-                <ContributorFeedback
-                  user={contributor}
-                  team={team}
-                  pitchId={pitchId}
-                />
-              ) : (
-                <Icon
-                  name="trash"
-                  link
-                  onClick={() => removeContributor(contributor._id)}
-                />
-              )}
-            </AuthView>
+            {!notApproved && (
+              <AuthView view="minStaff">
+                {completed ? (
+                  <ContributorFeedback
+                    user={contributor}
+                    team={team}
+                    pitchId={pitchId}
+                  />
+                ) : (
+                  <Icon
+                    name="trash"
+                    link
+                    onClick={() => removeContributor(contributor._id)}
+                  />
+                )}
+              </AuthView>
+            )}
           </div>
         ))}
       </div>

--- a/client/src/components/card/ApproveClaimCard.tsx
+++ b/client/src/components/card/ApproveClaimCard.tsx
@@ -150,7 +150,7 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
 
     apiCall({
       method: 'POST',
-      url: '/notifications/sendClaimRequestDenied',
+      url: '/notifications/sendClaimRequestDeclined',
       body: {
         contributorId: userId,
         pitchId: pitchId,
@@ -340,7 +340,12 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
                 <AuthView view="minStaff">
                   <Popup
                     content={message}
-                    trigger={<Icon size="small" name="question circle" />}
+                    trigger={
+                      <Icon
+                        style={{ fontSize: '16px' }}
+                        name="question circle"
+                      />
+                    }
                     wide="very"
                     position="top center"
                     hoverable

--- a/client/src/components/card/ApproveClaimCard.tsx
+++ b/client/src/components/card/ApproveClaimCard.tsx
@@ -11,6 +11,7 @@ import Swal from 'sweetalert2';
 
 import { FieldTag } from '..';
 import { apiCall, isError } from '../../api';
+import { useAuth } from '../../contexts';
 import { getUserFullName, pluralize } from '../../utils/helpers';
 import ContributorFeedback from '../modal/ContributorFeedback';
 import { SingleSelect } from '../select/SingleSelect';
@@ -37,6 +38,7 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
   notApproved,
   callback,
 }): ReactElement => {
+  const { user } = useAuth();
   const [selectContributorMode, setSelectContributorMode] = useState(false);
   const [filteredContribtors, setFilteredContributors] = useState<User[]>([]);
   const [allTeamContributors, setAllTeamContributors] = useState<User[] | null>(
@@ -78,6 +80,16 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
           writer: team.name === 'Writing',
         },
       });
+
+      apiCall({
+        method: 'POST',
+        url: '/notifications/sendContributorAdded',
+        body: {
+          contributorId: selectedContributor,
+          staffId: user?._id,
+          pitchId: pitchId,
+        },
+      });
     }
     setSelectContributorMode(false);
     await callback();
@@ -106,10 +118,20 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
       body: {
         userId: userId,
         teamId: team._id,
-        teams: [team.name],
       },
       query: {
         writer: team.name === 'Writing',
+      },
+    });
+
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendClaimRequestApproved',
+      body: {
+        contributorId: userId,
+        pitchId: pitchId,
+        staffId: user?._id,
+        teamId: team._id,
       },
     });
 
@@ -123,6 +145,16 @@ const ApproveClaimCard: FC<ApproveClaimCardProps> = ({
       body: {
         userId: userId,
         teamId: team._id,
+      },
+    });
+
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendClaimRequestDenied',
+      body: {
+        contributorId: userId,
+        pitchId: pitchId,
+        staffId: user?._id,
       },
     });
     await callback();

--- a/client/src/components/card/EditingClaimCard.tsx
+++ b/client/src/components/card/EditingClaimCard.tsx
@@ -241,6 +241,7 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
       return;
     }
 
+    //some random change
     if (from === editorTypeEnum.PRIMARY) {
       Swal.fire({
         title: 'Cannot remove only Primary Editor.',

--- a/client/src/components/card/EditingClaimCard.tsx
+++ b/client/src/components/card/EditingClaimCard.tsx
@@ -134,8 +134,7 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
     if (!(await shouldContinueEditorAPI(editorType))) {
       const temp = cloneDeep(temporaryContributors);
       temp[editorId].editorType = 'SECONDS';
-      console.log(temp);
-      setTemporaryContributors((t) => temp);
+      setTemporaryContributors(temp);
       return;
     }
 

--- a/client/src/components/card/EditingClaimCard.tsx
+++ b/client/src/components/card/EditingClaimCard.tsx
@@ -6,6 +6,7 @@ import Swal from 'sweetalert2';
 
 import { FieldTag } from '..';
 import { apiCall, isError } from '../../api';
+import { useAuth } from '../../contexts';
 import { EditorRecord, PendingEditorRecord } from '../../pages/Pitch';
 import { editorTypeEnum } from '../../utils/enums';
 import { getUserFullName } from '../../utils/helpers';
@@ -43,6 +44,7 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
   notApproved,
   callback,
 }): ReactElement => {
+  const { user } = useAuth();
   const [selectContributorMode, setSelectContributorMode] = useState(false);
   const [filteredContributors, setFilteredContributors] = useState<User[]>([]);
   const [selectedContributor, setSelectedContributor] = useState('');
@@ -73,6 +75,16 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
       body: {
         userId: userId,
         teamId: team._id,
+      },
+    });
+
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendClaimRequestDenied',
+      body: {
+        contributorId: userId,
+        pitchId: pitchId,
+        staffId: user?._id,
       },
     });
     await callback();
@@ -117,10 +129,20 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
       body: {
         userId: editorId,
         teamId: team._id,
-        teams: [team.name],
       },
       query: {
         editor: editorType,
+      },
+    });
+
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendClaimRequestApproved',
+      body: {
+        contributorId: editorId,
+        pitchId: pitchId,
+        staffId: user?._id,
+        teamId: team._id,
       },
     });
 
@@ -149,6 +171,16 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
       },
       query: {
         editor: editorType,
+      },
+    });
+
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendContributorAdded',
+      body: {
+        contributorId: editorId,
+        staffId: user?._id,
+        pitchId: pitchId,
       },
     });
 

--- a/client/src/components/card/EditingClaimCard.tsx
+++ b/client/src/components/card/EditingClaimCard.tsx
@@ -80,7 +80,7 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
 
     apiCall({
       method: 'POST',
-      url: '/notifications/sendClaimRequestDenied',
+      url: '/notifications/sendClaimRequestDeclined',
       body: {
         contributorId: userId,
         pitchId: pitchId,
@@ -397,7 +397,7 @@ const EditingClaimCard: FC<EditingClaimCardProps> = ({
                 <UserChip user={omit(user, 'editorType')} />
                 <Popup
                   content={message}
-                  trigger={<Icon size="small" name="question circle" />}
+                  trigger={<Icon size="massive" name="question circle" />}
                   wide="very"
                   position="top center"
                   hoverable

--- a/client/src/components/card/UserFeedback.scss
+++ b/client/src/components/card/UserFeedback.scss
@@ -32,4 +32,8 @@
   .pitch {
     color: $darkgrey;
   }
+
+  .stars {
+    width: min-content;
+  }
 }

--- a/client/src/components/card/UserFeedback.tsx
+++ b/client/src/components/card/UserFeedback.tsx
@@ -22,7 +22,7 @@ const UserFeedback: FC<UserFeedbackProps> = ({ feedback }) => (
         </p>
       </Grid.Column>
       <Grid.Column width={10}>
-        <div>
+        <div className="stars">
           <Rating
             className="rating"
             size="large"

--- a/client/src/components/filter/RadioFilter.tsx
+++ b/client/src/components/filter/RadioFilter.tsx
@@ -1,0 +1,38 @@
+import React, { FC } from 'react';
+import cn from 'classnames';
+import { useQueryParams, StringParam } from 'use-query-params';
+import { RadioProps, Form } from 'semantic-ui-react';
+
+interface RadioFilterProps extends RadioProps {
+  filterKey: string;
+  className?: string;
+}
+
+export const RadioFilter: FC<RadioFilterProps> = ({
+  filterKey,
+  className,
+  value = true,
+  ...rest
+}) => {
+  const [query, setQuery] = useQueryParams({
+    [filterKey]: StringParam,
+  });
+
+  const updateQuery = (): void => {
+    console.log(query[filterKey], value);
+    setQuery({
+      [filterKey]: query[filterKey] === `${value}` ? undefined : `${value}`,
+    });
+  };
+
+  return (
+    <Form.Radio
+      {...rest}
+      value={`${query[filterKey]}` || ''}
+      checked={query[filterKey] === `${value}`}
+      onChange={updateQuery}
+      className={cn(className)}
+      onClick={updateQuery}
+    />
+  );
+};

--- a/client/src/components/form/ClaimPitchForm.tsx
+++ b/client/src/components/form/ClaimPitchForm.tsx
@@ -25,11 +25,13 @@ export interface ClaimPitchFields {
 interface FormProps extends FormikConfig<ClaimPitchFields> {
   id?: string;
   pitch: FullPopulatedPitch | null;
+  disabled?: boolean;
 }
 
 export const ClaimPitchForm: FC<FormProps> = ({
   id = '',
   pitch,
+  disabled = false,
   ...rest
 }): ReactElement => {
   const { user } = useAuth();
@@ -91,6 +93,7 @@ export const ClaimPitchForm: FC<FormProps> = ({
                           )
                         }
                         label={getTargetLabel(team.teamId.name, team.target)}
+                        disabled={disabled}
                       />
                     )}
                   </Field>
@@ -107,6 +110,7 @@ export const ClaimPitchForm: FC<FormProps> = ({
             component={FormTextArea}
             name="message"
             maxLength={MAX_MESSAGE_LENGTH}
+            disabled={disabled}
           />
           <p id="word-limit">{values.message.length} / 250</p>
           {errors['message'] && touched['message'] && (

--- a/client/src/components/form/EditUserForm.tsx
+++ b/client/src/components/form/EditUserForm.tsx
@@ -14,7 +14,7 @@ import './EditUserForm.scss';
 const schema = yup.object({
   firstName: yup.string().required(),
   lastName: yup.string().required(),
-  preferredName: yup.string(),
+  preferredName: yup.string().nullable(),
   genders: yup.array().of(yup.string().required()).required().min(1),
   pronouns: yup.array().of(yup.string().required()).required().min(1),
   interests: yup.array().of(yup.string()).required().min(1).max(5),

--- a/client/src/components/form/SubmitPitchForm.tsx
+++ b/client/src/components/form/SubmitPitchForm.tsx
@@ -26,7 +26,7 @@ export interface SubmitPitchFields
     'title' | 'assignmentGoogleDocLink' | 'description' | 'topics'
   > {
   writerIntent?: string;
-  conflictOfInterest: string;
+  conflictOfInterest: string | null;
 }
 
 interface FormProps extends FormikConfig<SubmitPitchFields> {
@@ -59,16 +59,12 @@ export const SubmitPitchForm: FC<FormProps> = ({
       {({ touched, errors }) => (
         <FormikForm id={id}>
           <div className="form-wrapper">
-            {touched['title'] && errors['title'] && (
-              <div className="error">{errors['title']}</div>
-            )}
             <div className="row">
               <Field component={FormInput} name="title" label="Title" />
             </div>
-            {touched['assignmentGoogleDocLink'] &&
-              errors['assignmentGoogleDocLink'] && (
-                <div className="error">{errors['assignmentGoogleDocLink']}</div>
-              )}
+            {touched['title'] && errors['title'] && (
+              <div className="error">{errors['title']}</div>
+            )}
             <div className="row">
               <Field
                 component={FormInput}
@@ -76,9 +72,10 @@ export const SubmitPitchForm: FC<FormProps> = ({
                 label="Google Doc Link"
               />
             </div>
-            {touched['description'] && errors['description'] && (
-              <div className="error">{errors['description']}</div>
-            )}
+            {touched['assignmentGoogleDocLink'] &&
+              errors['assignmentGoogleDocLink'] && (
+                <div className="error">{errors['assignmentGoogleDocLink']}</div>
+              )}
             <div className="row">
               <Field
                 component={FormTextArea}
@@ -87,8 +84,8 @@ export const SubmitPitchForm: FC<FormProps> = ({
                 className="description"
               />
             </div>
-            {touched['topics'] && errors['topics'] && (
-              <div className="error">{errors['topics']}</div>
+            {touched['description'] && errors['description'] && (
+              <div className="error">{errors['description']}</div>
             )}
             <div className="row">
               <Field
@@ -101,11 +98,11 @@ export const SubmitPitchForm: FC<FormProps> = ({
                 }))}
               />
             </div>
+            {touched['topics'] && errors['topics'] && (
+              <div className="error">{errors['topics']}</div>
+            )}
             {isWriter && (
               <>
-                {touched['writerIntent'] && errors['writerIntent'] && (
-                  <div className="error">{errors['writerIntent']}</div>
-                )}
                 <div className="row">
                   <div>
                     <p>
@@ -129,12 +126,12 @@ export const SubmitPitchForm: FC<FormProps> = ({
                     </div>
                   </div>
                 </div>
+                {touched['writerIntent'] && errors['writerIntent'] && (
+                  <div className="error">{errors['writerIntent']}</div>
+                )}
               </>
             )}
 
-            {touched['conflictOfInterest'] && errors['conflictOfInterest'] && (
-              <div className="error">{errors['conflictOfInterest']}</div>
-            )}
             <div className="row">
               <div>
                 <p>
@@ -162,6 +159,9 @@ export const SubmitPitchForm: FC<FormProps> = ({
                 </div>
               </div>
             </div>
+            {touched['conflictOfInterest'] && errors['conflictOfInterest'] && (
+              <div className="error">{errors['conflictOfInterest']}</div>
+            )}
           </div>
         </FormikForm>
       )}

--- a/client/src/components/kanban/KanbanCard.tsx
+++ b/client/src/components/kanban/KanbanCard.tsx
@@ -22,7 +22,11 @@ const KanbanCard: FC<PitchProps> = ({ pitch, ...rest }): ReactElement => {
     >
       <p className="pitch-title">{pitch.title}</p>
       <div className="pitch-info">
-        <FieldTag size="small" content={pitch.editStatus} />
+        <FieldTag
+          size="small"
+          name={pitch.editStatus}
+          content={pitch.editStatus}
+        />
         <p className="pitch-text">
           Due{' '}
           {pitch.deadline

--- a/client/src/components/modal/ClaimPitch.tsx
+++ b/client/src/components/modal/ClaimPitch.tsx
@@ -87,7 +87,7 @@ export const ClaimPitch: FC<ClaimPitchProps> = ({
       return false;
     }
 
-    const isWriter = pitch.writer._id === user?._id;
+    const isWriter = pitch.writer?._id === user?._id;
     const isEditor =
       pitch.primaryEditor._id === user?._id ||
       pitch.secondEditors.some((editor) => editor._id === user?._id) ||

--- a/client/src/components/modal/ClaimPitch.tsx
+++ b/client/src/components/modal/ClaimPitch.tsx
@@ -87,11 +87,16 @@ export const ClaimPitch: FC<ClaimPitchProps> = ({
       return false;
     }
 
-    return (
-      pitch.assignmentContributors.findIndex(
-        (c) => c.userId._id === user!._id,
-      ) >= 0
+    const isWriter = pitch.writer._id === user?._id;
+    const isEditor =
+      pitch.primaryEditor._id === user?._id ||
+      pitch.secondEditors.some((editor) => editor._id === user?._id) ||
+      pitch.thirdEditors.some((editor) => editor._id === user?._id);
+    const isContributor = pitch.assignmentContributors.some(
+      (contributor) => contributor.userId._id === user?._id,
     );
+
+    return isWriter || isEditor || isContributor;
   }, [pitch, user]);
 
   const hasSubmittedClaim = useMemo(() => {
@@ -128,7 +133,7 @@ export const ClaimPitch: FC<ClaimPitchProps> = ({
         {hasClaimedPitch && (
           <Message
             header="Wait!"
-            content="You have already claimed this pitch"
+            content="You have already claimed this pitch. Please contact an Staff or Admin to claim this pitch."
             warning
           />
         )}
@@ -219,6 +224,7 @@ export const ClaimPitch: FC<ClaimPitchProps> = ({
           pitch={pitch}
           onSubmit={submitClaim}
           initialValues={{ message: '', teams: [] }}
+          disabled={hasClaimedPitch || hasSubmittedClaim}
         />
       </Modal.Content>
       <Modal.Actions>

--- a/client/src/components/modal/ClaimPitch.tsx
+++ b/client/src/components/modal/ClaimPitch.tsx
@@ -1,19 +1,19 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
-import { Divider, Icon, Modal, ModalProps, Message } from 'semantic-ui-react';
 import cn from 'classnames';
-import { FullPopulatedPitch } from 'ssw-common';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
+import { Divider, Icon, Message, Modal, ModalProps } from 'semantic-ui-react';
+import { FullPopulatedPitch } from 'ssw-common';
 
-import { PrimaryButton } from '../ui/PrimaryButton';
-import { Pusher } from '../ui/Pusher';
-import { LinkDisplay } from '../ui/LinkDisplayButton';
 import { apiCall, isError } from '../../api';
+import { useAuth } from '../../contexts';
+import { ClaimPitchFields, ClaimPitchForm } from '../form/ClaimPitchForm';
+import { PitchContributors } from '../list/PitchContributors';
 import { TagList } from '../list/TagList';
 import UserChip from '../tag/UserChip';
-import { useAuth } from '../../contexts';
-import { PitchContributors } from '../list/PitchContributors';
-import { ClaimPitchFields, ClaimPitchForm } from '../form/ClaimPitchForm';
-
+import { LinkDisplay } from '../ui/LinkDisplayButton';
+import { PrimaryButton } from '../ui/PrimaryButton';
+import { Pusher } from '../ui/Pusher';
+import { SecondaryButton } from '../ui/SecondaryButton';
 import './ClaimPitch.scss';
 
 interface ClaimPitchProps extends ModalProps {
@@ -139,6 +139,14 @@ export const ClaimPitch: FC<ClaimPitchProps> = ({
           <div>
             <LinkDisplay href={pitch?.assignmentGoogleDocLink || ''} />
           </div>
+          <Pusher />
+
+          <SecondaryButton
+            content="View Pitch"
+            color="grey"
+            border
+            onClick={() => window.open(`/pitch/${id}`)!.focus()}
+          />
         </div>
         <TagList tags={pitch?.topics || []} />
         <div className="description">{pitch?.description}</div>

--- a/client/src/components/modal/ContributorFeedback.tsx
+++ b/client/src/components/modal/ContributorFeedback.tsx
@@ -15,6 +15,7 @@ import { Team, UserFeedback, UserFields } from 'ssw-common';
 import { FieldTag } from '..';
 import { apiCall, isError } from '../../api';
 import UserChip from '../tag/UserChip';
+import { Pusher } from '../ui/Pusher';
 
 import './ContributorFeedback.scss';
 
@@ -129,10 +130,9 @@ const ContributorFeedback: FC<ClaimPitchProps> = ({
       {...rest}
     >
       <Modal.Header>
-        <div className="modal-header">
-          Leave Feedback
-          <Icon name="close" onClick={() => setIsOpen(false)} />
-        </div>
+        Leave Feedback
+        <Pusher />
+        <Icon name="close" onClick={() => setIsOpen(false)} />
       </Modal.Header>
       <Modal.Content scrolling>
         <div className="modal-content">

--- a/client/src/components/modal/EditableTag.tsx
+++ b/client/src/components/modal/EditableTag.tsx
@@ -50,7 +50,7 @@ const EditableTagModal: FC<EditableTagModalProps> = ({
 
     setClonedTags([...clone]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onFetch]);
+  }, [onFetch, isOpen]);
 
   // Add a new field in form
   const addInputLine = (): void => {
@@ -126,7 +126,7 @@ const EditableTagModal: FC<EditableTagModalProps> = ({
 
     Swal.fire({
       icon: 'question',
-      text: `Are you sure you want to save your ${title} changes?`,
+      text: `Are you sure you want to save your ${title} changes? If you are adding new tags, you will not be able to delete them.`,
       showCancelButton: true,
       cancelButtonText: 'Cancel',
       confirmButtonText: 'Confirm',
@@ -139,13 +139,7 @@ const EditableTagModal: FC<EditableTagModalProps> = ({
           onUpdate(changedTags);
         }
         onFetch();
-
-        Swal.fire(
-          `${title} updated!`,
-          `${title} tags has been updated`,
-          'success',
-        );
-        setIsOpen(false);
+        location.reload();
       }
     });
   };

--- a/client/src/components/modal/ResourceControl.tsx
+++ b/client/src/components/modal/ResourceControl.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useEffect, useMemo, useState } from 'react';
+import React, { FC, ReactElement, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { Form, Icon, Modal, ModalProps } from 'semantic-ui-react';
 import { Resource } from 'ssw-common';
@@ -58,10 +58,6 @@ const ResourceModal: FC<ResourceProps> = ({
     }
   };
 
-  useEffect(() => {
-    console.log(isOpen);
-  }, [isOpen]);
-
   const submitResourceForm = (resource: Resource): void => {
     const body = {
       name: resource.name,
@@ -80,6 +76,7 @@ const ResourceModal: FC<ResourceProps> = ({
 
       if (!isError(res)) {
         setOpen?.(false);
+        setIsOpen(false);
         toast.success(
           `Successfully ${
             action === 'create' ? 'created' : 'updated'
@@ -93,7 +90,6 @@ const ResourceModal: FC<ResourceProps> = ({
     };
 
     manageResource();
-    setIsOpen(false);
   };
 
   return (

--- a/client/src/components/modal/ReviewPitch.tsx
+++ b/client/src/components/modal/ReviewPitch.tsx
@@ -130,6 +130,28 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
       body: pitchData,
     });
 
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendPitchApproved',
+      body: {
+        contributorId: pitch?.author._id,
+        pitchId: pitch?._id,
+        reviewerId: user?._id,
+      },
+    });
+
+    if (pitchData.writer !== user?._id) {
+      apiCall({
+        method: 'POST',
+        url: '/notifications/sendContributorAdded',
+        body: {
+          contributorId: pitch?.author._id,
+          staffId: user?._id,
+          pitchId: pitch?._id,
+        },
+      });
+    }
+
     if (!isError(res)) {
       toast.success('Pitch approved');
       setOpen(false);
@@ -144,6 +166,17 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
       method: 'PUT',
       body: {
         reasoning,
+      },
+    });
+
+    apiCall({
+      method: 'POST',
+      url: '/notifications/sendPitchDeclined',
+      body: {
+        contributorId: pitch?.author._id,
+        staffId: user?._id,
+        pitchId: pitch?._id,
+        reasoning: reasoning,
       },
     });
 

--- a/client/src/components/modal/ReviewPitch.tsx
+++ b/client/src/components/modal/ReviewPitch.tsx
@@ -140,12 +140,14 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
       },
     });
 
-    if (pitchData.writer !== user?._id) {
+    console.log(pitchData.writer, pitch?.author._id);
+
+    if (pitchData.writer && pitchData.writer !== pitch?.author._id) {
       apiCall({
         method: 'POST',
         url: '/notifications/sendContributorAdded',
         body: {
-          contributorId: pitch?.author._id,
+          contributorId: pitchData.writer,
           staffId: user?._id,
           pitchId: pitch?._id,
         },

--- a/client/src/components/modal/ReviewPitch.tsx
+++ b/client/src/components/modal/ReviewPitch.tsx
@@ -83,7 +83,7 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
       const pitch = await loadBasePitch(id);
 
       setPitch(pitch);
-      setWriter(pitch && pitch.writer && pitch.writer._id);
+      setWriter(pitch && pitch.writer && pitch.writer?._id);
     };
 
     if (open) {

--- a/client/src/components/modal/SubmitPitchModal.tsx
+++ b/client/src/components/modal/SubmitPitchModal.tsx
@@ -120,7 +120,7 @@ export const SubmitPitchModal: FC<SubmitPitchModalProps> = ({
       description: '',
       assignmentGoogleDocLink: '',
       topics: [],
-      conflictOfInterest: 'false',
+      conflictOfInterest: null,
       writerIntent: undefined,
     };
   }, [pitch, user]);

--- a/client/src/components/modal/ViewPitchFeedback/ViewPitchFeedback.scss
+++ b/client/src/components/modal/ViewPitchFeedback/ViewPitchFeedback.scss
@@ -2,6 +2,7 @@
   width: 75% !important;
 
   .content {
+    min-height: 400px !important;
     .questions-select {
       width: 100%;
     }

--- a/client/src/components/modal/ViewPitchFeedback/ViewPitchFeedback.tsx
+++ b/client/src/components/modal/ViewPitchFeedback/ViewPitchFeedback.tsx
@@ -76,7 +76,7 @@ export const ViewPitchFeedback: FC<PitchFeedbackProps> = ({
       {...rest}
     >
       <Modal.Header>
-        View Contributor Feedback
+        View Pitch Feedback
         <Pusher />
         <Icon name="close" onClick={() => setIsOpen(false)} />
       </Modal.Header>

--- a/client/src/components/table/PitchRecords.tsx
+++ b/client/src/components/table/PitchRecords.tsx
@@ -121,7 +121,6 @@ export const PitchRecords: FC<TableProps> = ({
       columns={cols}
       records={data}
       count={count}
-      pageOptions={['1', '10', '25', '50']}
       getModal={getModal}
       onRecordClick={onRecordClick}
       sortType="query"

--- a/client/src/components/table/ResourceRecords.tsx
+++ b/client/src/components/table/ResourceRecords.tsx
@@ -35,7 +35,6 @@ export const ResourceRecords: FC<TableProps> = ({
   return (
     <PaginatedTable<Resource>
       count={count}
-      pageOptions={['1', '10', '25', '50']}
       sortType="query"
       sortable
       records={resources}

--- a/client/src/components/table/UserRecords.tsx
+++ b/client/src/components/table/UserRecords.tsx
@@ -142,7 +142,6 @@ export const UsersRecords: FC<TableProps> = ({
   return (
     <PaginatedTable<BasePopulatedUser>
       count={count}
-      pageOptions={['1', '10', '25', '50']}
       sortType="query"
       sortable
       records={users}

--- a/client/src/components/table/UserRecords.tsx
+++ b/client/src/components/table/UserRecords.tsx
@@ -88,7 +88,7 @@ export const UsersRecords: FC<TableProps> = ({
   type,
   onModalClose,
 }) => {
-  const { isAdmin } = useAuth();
+  const { isAdmin, user: currentUser } = useAuth();
 
   const actionColumn = configureColumn<BasePopulatedUser>({
     title: '',
@@ -100,7 +100,7 @@ export const UsersRecords: FC<TableProps> = ({
             size="mini"
             onClick={async (e) => {
               e.stopPropagation();
-              await approveUser(user);
+              await approveUser(user, currentUser);
               if (onModalClose) {
                 onModalClose();
               }
@@ -111,7 +111,7 @@ export const UsersRecords: FC<TableProps> = ({
             size="mini"
             onClick={async (e) => {
               e.stopPropagation();
-              await rejectUser(user);
+              await rejectUser(user, currentUser);
               if (onModalClose) {
                 onModalClose();
               }

--- a/client/src/components/table/columns.tsx
+++ b/client/src/components/table/columns.tsx
@@ -139,17 +139,18 @@ export const joinedColumn = configureColumn<BasePopulatedUser>({
 export const actionColumn = configureColumn<BasePopulatedUser>({
   title: '',
   width: 2,
-  extractor: function getAction(user: BasePopulatedUser) {
+  extractor: function GetAction(user: BasePopulatedUser) {
+    const { user: currentUser } = useAuth();
     return (
       <div style={{ display: 'flex' }}>
         <PrimaryButton
           size="mini"
-          onClick={() => approveUser(user)}
+          onClick={() => approveUser(user, currentUser)}
           content="Approve"
         />
         <SecondaryButton
           size="mini"
-          onClick={() => rejectUser(user)}
+          onClick={() => rejectUser(user, currentUser)}
           content="Decline"
           border
         />

--- a/client/src/components/table/dynamic/DynamicTable2.0.tsx
+++ b/client/src/components/table/dynamic/DynamicTable2.0.tsx
@@ -74,6 +74,7 @@ export interface DynamicTableProps<T> extends Omit<TableProps, 'columns'> {
   footer?: ReactNode;
   sortType?: 'internal' | 'query';
   noHeader?: boolean;
+  priority?: 'modal' | 'record-action';
 }
 
 /**
@@ -103,6 +104,7 @@ const DynamicTable = <T,>({
   emptyMessage = 'No records found',
   sortType = 'internal',
   noHeader = false,
+  priority,
   ...rest
 }: DynamicTableProps<T>): ReactElement => {
   const [sortedRecords, setSortedRecords] = useState(records);
@@ -221,6 +223,18 @@ const DynamicTable = <T,>({
    * @param record the record being clicked
    */
   const handleRecordClick = (record: T): void => {
+    console.log(priority);
+
+    if (priority && priority === 'record-action') {
+      onRecordClick?.(record);
+      return;
+    } else if (priority && priority === 'modal' && getModal) {
+      console.log('here');
+      setClickedRecord(record);
+      setIsModalOpen(true);
+      return;
+    }
+
     if (onRecordClick) {
       onRecordClick(record);
     }

--- a/client/src/components/table/dynamic/PaginatedTable.tsx
+++ b/client/src/components/table/dynamic/PaginatedTable.tsx
@@ -8,13 +8,13 @@ import { SingleSelect } from '../../select/SingleSelect';
 import DynamicTable, { DynamicTableProps } from './DynamicTable2.0';
 
 interface PaginateOptions<T> extends DynamicTableProps<T> {
-  pageOptions: string[];
+  pageOptions?: string[];
   count: number;
 }
 
 export const PaginatedTable = <T,>({
   count,
-  pageOptions,
+  pageOptions = ['10', '25', '50'],
   ...rest
 }: PaginateOptions<T>): ReactElement => {
   const [query, setQuery] = useQueryParams({

--- a/client/src/components/tag/UserChip.tsx
+++ b/client/src/components/tag/UserChip.tsx
@@ -15,7 +15,11 @@ const UserChip: FC<UserChipProps> = ({ user, className }) => {
   }
 
   return (
-    <a className={className} href={`/profile/${user._id}`}>
+    <a
+      onClick={(e) => e.stopPropagation()}
+      className={className}
+      href={`/profile/${user._id}`}
+    >
       <span className={cn('user-chip-wrapper')}>
         <img src={user.profilePic} alt={user.fullname} />
         {user.shortName}

--- a/client/src/components/view/HomepageView.tsx
+++ b/client/src/components/view/HomepageView.tsx
@@ -37,13 +37,21 @@ export const HomepageView: FC<HomepageViewProps> = ({ type }): ReactElement => {
   const queryParams = useMemo(() => {
     const params = new URLSearchParams(location.search);
 
+    let isPublished = undefined;
+
+    if (type === 'published') {
+      isPublished = true;
+    } else if (type === 'member') {
+      isPublished = false;
+    }
+
     const q = {
       limit: params.get('limit') || '10',
       offset: params.get('offset') || '0',
       search: params.get('search'),
       'teams.teamId__all': params.get('teams__all'),
       topics__all: params.get('interests__all'),
-      isPublished: type === 'published' || undefined,
+      isPublished: isPublished,
       author: type === 'submitted' ? user?._id : undefined,
       sortBy: params.get('sortBy'),
       orderBy: params.get('orderBy'),

--- a/client/src/components/view/PitchesView.tsx
+++ b/client/src/components/view/PitchesView.tsx
@@ -15,9 +15,9 @@ import toast from 'react-hot-toast';
 import { isError, apiCall } from '../../api';
 import { MultiSelectFilter } from '../filter/MultiSelectFilter';
 import { DelayedSearch } from '../search/DelayedSearch';
-import { CheckboxFilter } from '../filter/CheckboxFilter';
 import { PitchRecords } from '../table/PitchRecords';
 import { useAuth } from '../../contexts';
+import { RadioFilter } from '../filter/RadioFilter';
 
 interface PitchesRes {
   data: BasePopulatedPitch[];
@@ -109,12 +109,12 @@ export const PitchesView: FC<PitchesViewProps> = ({ type }): ReactElement => {
           <div id="search">
             <DelayedSearch id="search" />
           </div>
-          <CheckboxFilter
+          <RadioFilter
             className="publish-date-checkbox"
             label="Has Publish Date"
             filterKey="hasPublishDate"
           />
-          <CheckboxFilter
+          <RadioFilter
             label="Has No Publish Date"
             value="false"
             filterKey="hasPublishDate"

--- a/client/src/components/wrapper/PrivateRoute.tsx
+++ b/client/src/components/wrapper/PrivateRoute.tsx
@@ -22,13 +22,16 @@ export const PrivateRoute: FC<RouteProps> = ({
   }
 
   if (user && user.role === 'TBD' && location.pathname !== '/join') {
-    console.log('HERERERERE');
     return <Redirect to="/join" />;
   } else if (!isAuthenticated && location.pathname !== '/login') {
     return <Redirect to="/login" />;
   } else if (!isRegistered) {
     <Redirect to="/join" from={location.pathname} />;
-  } else if (!isOnboarded && location.pathname !== '/resources') {
+  } else if (
+    !isOnboarded &&
+    location.pathname !== '/resources' &&
+    location.pathname !== '/join'
+  ) {
     return <Redirect to="/resources" from={location.pathname} />;
   }
 

--- a/client/src/contexts/teams/provider.tsx
+++ b/client/src/contexts/teams/provider.tsx
@@ -18,6 +18,7 @@ const TeamsProvider: FC = ({ children }): ReactElement => {
     teams.find(({ _id }) => _id === teamId) || initialValues.getTeamFromId();
 
   const fetchTeams = useCallback(async () => {
+    console.log('fetching teams');
     const res = await apiCall<Team[]>({
       url: '/teams',
       method: 'GET',

--- a/client/src/pages/Issues.tsx
+++ b/client/src/pages/Issues.tsx
@@ -69,6 +69,8 @@ const Issues = (): ReactElement => {
         <AddIssueModal />
       </div>
     );
+  } else if (viewIssueIndex < 0 || viewIssueIndex >= issues.length) {
+    return <></>;
   }
 
   return (

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -229,7 +229,7 @@ const Profile = (): ReactElement => {
     if (
       pitch.secondEditors.find(({ _id }) => _id === userId) ||
       pitch.thirdEditors.find(({ _id }) => _id === userId) ||
-      pitch.primaryEditor._id === userId
+      pitch.primaryEditor?._id === userId
     ) {
       const editingTeam = currentUser?.teams.find(
         ({ name }) => name === 'Editing',
@@ -390,13 +390,7 @@ const Profile = (): ReactElement => {
           records={pitchesData.data}
           count={pitchesData.count}
           pageOptions={['1', '10', '25', '50']}
-          onRecordClick={(pitch) => {
-            if (pitch.status !== pitchStatusEnum.APPROVED) {
-              return;
-            }
-
-            history.push(`/pitch/${pitch._id}`);
-          }}
+          onRecordClick={(pitch) => history.push(`/pitch/${pitch._id}`)}
           sortable
           sortType="query"
         />

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -212,15 +212,33 @@ const Profile = (): ReactElement => {
   });
 
   const getTeamsForPitch = (pitch: BasePopulatedPitch): Team[] => {
-    const contributor = pitch.assignmentContributors.find(
-      (contributor) => contributor.userId._id === userId,
-    );
-
-    if (!contributor) {
-      return [];
+    const teams: Team[] = [];
+    pitch.assignmentContributors.map((contributor) => {
+      if (contributor.userId._id === userId) {
+        contributor.teams.map((t) => teams.push(t));
+      }
+    });
+    if (pitch.writer._id === userId) {
+      const writingTeam = currentUser?.teams.find(
+        ({ name }) => name === 'Writing',
+      );
+      if (writingTeam) {
+        teams.push(writingTeam);
+      }
     }
-
-    return contributor.teams;
+    if (
+      pitch.secondEditors.find(({ _id }) => _id === userId) ||
+      pitch.thirdEditors.find(({ _id }) => _id === userId) ||
+      pitch.primaryEditor._id === userId
+    ) {
+      const editingTeam = currentUser?.teams.find(
+        ({ name }) => name === 'Editing',
+      );
+      if (editingTeam) {
+        teams.push(editingTeam);
+      }
+    }
+    return teams;
   };
 
   const teamsColumn = configureColumn<BasePopulatedPitch>({

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -218,7 +218,7 @@ const Profile = (): ReactElement => {
         contributor.teams.map((t) => teams.push(t));
       }
     });
-    if (pitch.writer._id === userId) {
+    if (pitch.writer?._id === userId) {
       const writingTeam = currentUser?.teams.find(
         ({ name }) => name === 'Writing',
       );

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -22,7 +22,7 @@ import { FieldTag, UserPicture } from '../components';
 import { configureColumn } from '../components/table/dynamic/DynamicTable2.0';
 import UserFeedback from '../components/card/UserFeedback';
 import { EditUserModal } from '../components/modal/EditUser';
-import { useAuth } from '../contexts';
+import { useAuth, useTeams } from '../contexts';
 import { TagList } from '../components/list/TagList';
 import { IconLabel } from '../components/ui/IconLabel';
 import { PaginatedTable } from '../components/table/dynamic/PaginatedTable';
@@ -45,6 +45,7 @@ interface FeedbackRes {
 }
 
 const Profile = (): ReactElement => {
+  const { teams: allTeams } = useTeams();
   const { userId } = useParams<{ userId: string }>();
   const { user: currentUser, isAdmin, isStaff } = useAuth();
   const [queries, setQueries] = useQueryParams({
@@ -218,9 +219,7 @@ const Profile = (): ReactElement => {
       }
     });
     if (pitch.writer?._id === userId) {
-      const writingTeam = currentUser?.teams.find(
-        ({ name }) => name === 'Writing',
-      );
+      const writingTeam = allTeams.find(({ name }) => name === 'Writing');
       if (writingTeam) {
         teams.push(writingTeam);
       }
@@ -230,9 +229,7 @@ const Profile = (): ReactElement => {
       pitch.thirdEditors.find(({ _id }) => _id === userId) ||
       pitch.primaryEditor?._id === userId
     ) {
-      const editingTeam = currentUser?.teams.find(
-        ({ name }) => name === 'Editing',
-      );
+      const editingTeam = allTeams.find(({ name }) => name === 'Editing');
       if (editingTeam) {
         teams.push(editingTeam);
       }

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -30,7 +30,6 @@ import { apiCall, isError } from '../api';
 import { SingleSelect } from '../components/select/SingleSelect';
 import { parseOptionsSelect } from '../utils/helpers';
 import Loading from '../components/ui/Loading';
-import { pitchStatusEnum } from '../utils/enums';
 import { pitchStatusCol } from '../components/table/columns';
 
 import './Profile.scss';

--- a/client/src/utils/neighborhoods.ts
+++ b/client/src/utils/neighborhoods.ts
@@ -1,4 +1,5 @@
 const neighborhoods = [
+  'NA',
   'Albany Park',
   'Altgeld Gardens',
   'Andersonville',

--- a/client/src/wizard/stages/Completion.tsx
+++ b/client/src/wizard/stages/Completion.tsx
@@ -1,21 +1,16 @@
 import React, { ReactElement, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Button, Segment } from 'semantic-ui-react';
-import Swal from 'sweetalert2';
 
 import { useAuth } from '../../contexts';
-import { openProfile } from '../../utils/helpers';
 
 import './Completion.scss';
 
 const Completion = (): ReactElement => {
-  const { register, user } = useAuth();
+  const { register } = useAuth();
+  const history = useHistory();
 
   useEffect(() => {
-    Swal.fire({
-      title: 'Account created!',
-      icon: 'success',
-    });
-
     register();
   }, [register]);
 
@@ -33,7 +28,7 @@ const Completion = (): ReactElement => {
         className="default-btn"
         fluid
         content="Go to Dashboard"
-        onClick={() => openProfile(user!)}
+        onClick={() => history.push('/resources')}
       />
     </div>
   );

--- a/client/src/wizard/stages/onboarding/Onboard5.tsx
+++ b/client/src/wizard/stages/onboarding/Onboard5.tsx
@@ -40,7 +40,7 @@ const Onboard5 = (): ReactElement => {
       onboardingStatus: 'ONBOARDING_SCHEDULED',
       involvementResponse: data!.involvementResponse,
       journalismResponse: data!.journalismResponse,
-      neighborhood: data!.neighborhood,
+      neighborhood: data!.neighborhood || 'NA',
       teams: [...new Set(data!.teams)],
       role: data!.role,
       races: reject(data!.races, isEmpty),


### PR DESCRIPTION
- [x] Add message to swal popup to let users know to refresh editable tags when updated/created
- [x] Fix api endpiont for yaml update-stall-users
- [x] Contributors can see private resources
- [x] Radio buttons for pitch doc haspublishedate filtering
- [x] 3rds needed label on issue cards turns into "3 Rds Needed"
- [x] Can't edit pitch after submission
- [x] Date on Pitch page for Associated issue is 1 day ahead (old bug?)
     - confirmed to not be an issue
- [x] Message for Primary Editor replacing other primary editor isn't showing up anymore - get back to this
- [x] If i add a a user to a team (not editing) and there is still space left on that team to fill into, it still increases the number of people needed
- [x] Stop Propagation on user tag clicks
- [x] Preferred name should be required by YUP on the edit profile modal (add .nullable())
- [x] Send email to primary editor/second/third editor if they are added
- [x] after removing myself from a pitch, it still thinks I am on it (not removing from assignment contributors if teams array is 0)
- [x] It doesn't restrict claiming again if I am already an Editor (doesn't check that)
- [x] Add view pitch button to claim pitch modal
- [x] Add link to pending and declined rows on profile page
- [x] Teams your on column doesn't recognize that you are on editing or writing (I think) on Profile Page
- [x] Your Current pitches should filter out published pitches
- [x] Stars on feedback cards are too spread out
   - check production
- [x] Ensure all Modal Close "X"s are aligned right

## Email Bugs 
- [x] Claim Request Denied email not coming through?
- [x] Didn't send email to writer either
- [x] Pitch approved email no longer sending?
- [x] User rejection email not sending?
     - confirmed to work in dev env


Stretch:
- [ ] Allow table to refresh after submitting new resource/pitch
- [x] Fix conflict default to "no" on review pitch modal